### PR TITLE
refactor(api): request 유틸에 함수 오버로드 적용 및 응답 타입 추론 개선

### DIFF
--- a/apps/client/src/features/auth/api.ts
+++ b/apps/client/src/features/auth/api.ts
@@ -1,4 +1,3 @@
-// auth.service.ts
 import request from "../../shared/lib/request";
 import { ApiResponse } from "packages/types/src";
 import {
@@ -11,33 +10,27 @@ import {
   FindIdResponse,
 } from "./model";
 
-export const loginUser = async (
-  userData: UserLogin
-): Promise<ApiResponse<null>> => {
-  return (await request<null>(
+export const loginUser = (userData: UserLogin): Promise<ApiResponse<null>> =>
+  request<null>(
     "/v1/auth/login",
     {
       method: "POST",
       body: JSON.stringify(userData),
     },
     "full"
-  )) as ApiResponse<null>;
-};
+  );
 
-export const createUser = async (
-  userData: UserSignUp
-): Promise<ApiResponse<null>> => {
-  return (await request<null>(
+export const createUser = (userData: UserSignUp): Promise<ApiResponse<null>> =>
+  request<null>(
     "/v1/users",
     {
       method: "POST",
       body: JSON.stringify(userData),
     },
     "full"
-  )) as ApiResponse<null>;
-};
+  );
 
-export const userFindId = async (
+export const userFindId = (
   params: UserFindId
 ): Promise<ApiResponse<FindIdResponse>> => {
   const query = new URLSearchParams({
@@ -45,60 +38,48 @@ export const userFindId = async (
     userEmail: params.userEmail,
   }).toString();
 
-  return (await request<FindIdResponse>(
+  return request<FindIdResponse>(
     `/v1/users/find/id?${query}`,
     { method: "GET" },
     "full"
-  )) as ApiResponse<FindIdResponse>;
+  );
 };
 
-export const userFindPw = async (
-  userData: UserFindPw
-): Promise<ApiResponse<null>> => {
-  return (await request<null>(
+export const userFindPw = (userData: UserFindPw): Promise<ApiResponse<null>> =>
+  request<null>(
     "/v1/users/find/password",
     {
       method: "POST",
       body: JSON.stringify(userData),
     },
     "full"
-  )) as ApiResponse<null>;
-};
+  );
 
-export const smsSend = async (
-  userData: PhoneNumber
-): Promise<ApiResponse<null>> => {
-  return (await request<null>(
+export const smsSend = (userData: PhoneNumber): Promise<ApiResponse<null>> =>
+  request<null>(
     "/v1/sms/send",
     {
       method: "POST",
       body: JSON.stringify(userData),
     },
     "full"
-  )) as ApiResponse<null>;
-};
+  );
 
-export const smsVerify = async (
-  userData: PhoneVerify
-): Promise<ApiResponse<null>> => {
-  return (await request<null>(
+export const smsVerify = (userData: PhoneVerify): Promise<ApiResponse<null>> =>
+  request<null>(
     "/v1/sms/verify",
     {
       method: "POST",
       body: JSON.stringify(userData),
     },
     "full"
-  )) as ApiResponse<null>;
-};
+  );
 
-export const duplicationCheckId = async (
+export const duplicationCheckId = (
   loginId: string
-): Promise<ApiResponse<null>> => {
-  return (await request<null>(
+): Promise<ApiResponse<null>> =>
+  request<null>(
     `/v1/users/check/id?loginId=${encodeURIComponent(loginId)}`,
-    {
-      method: "GET",
-    },
+    { method: "GET" },
     "full"
-  )) as ApiResponse<null>;
-};
+  );

--- a/apps/client/src/shared/lib/request.ts
+++ b/apps/client/src/shared/lib/request.ts
@@ -37,6 +37,18 @@ async function handleResponse<T>(
   return mode === "data" ? resData.data : resData;
 }
 
+export default function request<T>(
+  url: string | URL,
+  options?: RequestInit,
+  mode?: "data"
+): Promise<T>;
+
+export default function request<T>(
+  url: string | URL,
+  options: RequestInit | undefined,
+  mode: "full"
+): Promise<ApiResponse<T>>;
+
 // 요청 함수
 export default async function request<T>(
   url: string | URL,


### PR DESCRIPTION
## 💻 작업 내용
- request 유틸에 함수 오버로드 추가
- mode("data" | "full")에 따른 반환 타입 정확히 추론하도록 개선
- 서비스 레이어에서 반복되던 ApiResponse 타입 단언 캐스팅 제거

<br></br>
## 💬 추가 전달 사항
관련 수정 과정 [api 오퍼로드 도입](https://www.notion.so/API-request-31a1aba5f28980a89b04e86b6371e65f?v=2f71aba5f2898031ad0a000cd41be6b1&source=copy_link)

<br></br>
## 💁‍♂️ 관련 Issues
#25 
