### PR TITLE
fix: api 요청을 위한 base url을 localhost에서 환경변수로 변경

### DIFF
--- a/apps/client/src/shared/lib/request.ts
+++ b/apps/client/src/shared/lib/request.ts
@@ -3,15 +3,13 @@ import { isApiResponse } from "./api-response.guard";
 import { ApiResponse } from "@repo/types";
 
 function getBaseUrl() {
-  if (typeof window !== "undefined") {
-    return "";
+  if (typeof window !== "undefined") return "";
+
+  if (!process.env.NEXT_PUBLIC_SITE_URL) {
+    throw new Error("환경 변수가 없습니다");
   }
 
-  if (process.env.NEXT_PUBLIC_SITE_URL) {
-    return process.env.NEXT_PUBLIC_SITE_URL;
-  }
-
-  return "http://localhost:3000";
+  return process.env.NEXT_PUBLIC_SITE_URL;
 }
 
 async function handleResponse<T>(


### PR DESCRIPTION
## 💻 작업 내용
- API 요청 시 base URL을 `localhost`로 고정하던 로직 제거
- 환경변수(`NEXT_PUBLIC_SITE_URL`) 기반으로 base URL을 동적으로 설정하도록 수정
- SSR 환경에서 절대 경로로 API 요청이 가능하도록 개선
- 로컬 및 배포 환경에서 동일하게 동작하도록 수정

<br></br>
## 💬 추가 전달 사항
- `.env.local` 및 배포 환경에 `NEXT_PUBLIC_SITE_URL` 설정이 필요합니다.
- (개발: http://localhost:3000 배포: https://www.daebbang-sister.shop)

<br></br>
## 💁‍♂️ 관련 Issues
#70 
