### PR TITLE
fix: 비로그인 상태에서 토큰 갱신 요청 제거

### DIFF
--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -5,6 +5,7 @@ import SearchBar from "@/shared/components/layout/SearchBar";
 import SideNavi from "@/shared/components/layout/SideNavi";
 import Footer from "@/shared/components/layout/Footer";
 import QuickBanner from "@/shared/components/floating/QuickBanner";
+import { cookies } from "next/headers";
 import Providers from "@/shared/components/Providers";
 
 export const metadata = {
@@ -17,15 +18,18 @@ export const metadata = {
   },
   description: "대빵언니 쇼핑몰",
 };
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const cookieStore = await cookies();
+  const hasSession = cookieStore.has("refresh");
+
   return (
     <html lang="ko" suppressHydrationWarning>
       <body suppressHydrationWarning>
-        <Providers>
+        <Providers initialLoggedIn={hasSession}>
           <LayoutUIProvider>
             <QuickBanner />
             <Header />

--- a/apps/client/src/shared/components/Providers.tsx
+++ b/apps/client/src/shared/components/Providers.tsx
@@ -6,9 +6,13 @@ import { useAuthStore } from "@/shared/store/auth.store";
 
 type ProvidersProps = {
   children: React.ReactNode;
+  initialLoggedIn: boolean;
 };
 
-export default function Providers({ children }: ProvidersProps) {
+export default function Providers({
+  children,
+  initialLoggedIn,
+}: ProvidersProps) {
   const [isReady, setIsReady] = useState(false);
   const { login, logout } = useAuthStore();
 
@@ -25,6 +29,10 @@ export default function Providers({ children }: ProvidersProps) {
   );
 
   useEffect(() => {
+    if (!initialLoggedIn) {
+      setIsReady(true);
+      return;
+    }
     const refresh = async () => {
       try {
         const res = await fetch("/api/proxy/v1/tokens/reissues", {


### PR DESCRIPTION
## 💻 작업 내용
- 서버 컴포넌트(layout.tsx)에서 refresh_token 쿠키 존재 여부를 확인하여 Providers에 initialLoggedIn prop으로 전달
- 비로그인 상태일 경우 POST /api/proxy/v1/tokens/reissues 요청을 보내지 않도록 조건부 처리

<br></br>
## 💬 추가 전달 사항
불필요한 토큰 갱신 요청을 제거했습니다.

<br></br>
## 💁‍♂️ 관련 Issues
closes #90 
