### PR TITLE
refactor: Modal Compound Component → named export 방식으로 변경

### DIFF
--- a/apps/client/src/app/test/page.tsx
+++ b/apps/client/src/app/test/page.tsx
@@ -1,6 +1,13 @@
 "use client";
 import { useState } from "react";
-import { Modal } from "@repo/ui";
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from "@repo/ui";
 
 export default function TestPage() {
   const [isOpen, setIsOpen] = useState(false);
@@ -10,17 +17,17 @@ export default function TestPage() {
       <button onClick={() => setIsOpen(true)}>모달 열기</button>
 
       <Modal isOpen={isOpen} onClose={() => setIsOpen(false)}>
-        <Modal.Overlay />
-        <Modal.Content className="w-full max-w-97.5">
-          <Modal.Header title="테스트" />
-          <Modal.Body>
+        <ModalOverlay />
+        <ModalContent className="w-full max-w-97.5">
+          <ModalHeader title="테스트" />
+          <ModalBody>
             <h1>바디</h1>
-          </Modal.Body>
-          <Modal.Footer>
+          </ModalBody>
+          <ModalFooter>
             <button onClick={() => setIsOpen(false)}>취소</button>
             <button onClick={() => setIsOpen(false)}>확인</button>
-          </Modal.Footer>
-        </Modal.Content>
+          </ModalFooter>
+        </ModalContent>
       </Modal>
     </div>
   );

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -9,3 +9,8 @@ export { Quantity } from "./quantity/Quantity";
 export { XButton } from "./button/XButton";
 export { Modal } from "./modal/Modal";
 export { useModalContext } from "./modal/ModalContext";
+export { Overlay as ModalOverlay } from "./modal/Overlay";
+export { Content as ModalContent } from "./modal/Content";
+export { Header as ModalHeader } from "./modal/Header";
+export { Body as ModalBody } from "./modal/Body";
+export { Footer as ModalFooter } from "./modal/Footer";

--- a/packages/ui/src/modal/Modal.tsx
+++ b/packages/ui/src/modal/Modal.tsx
@@ -2,11 +2,6 @@
 import React from "react";
 import { Portal } from "./Portal";
 import ModalContext from "./ModalContext";
-import { Overlay } from "./Overlay";
-import { Content } from "./Content";
-import { Header } from "./Header";
-import { Body } from "./Body";
-import { Footer } from "./Footer";
 
 type ModalProps = {
   children: React.ReactNode;
@@ -21,9 +16,3 @@ export function Modal({ children, onClose, isOpen }: ModalProps) {
     </ModalContext.Provider>
   );
 }
-
-Modal.Overlay = Overlay;
-Modal.Content = Content;
-Modal.Header = Header;
-Modal.Body = Body;
-Modal.Footer = Footer;


### PR DESCRIPTION
## 💻 작업 내용
- Modal.Overlay, Modal.Content 등 → ModalOverlay, ModalContent 등으로 분리
- index.ts에 Modal 서브 컴포넌트 named export 추가
- 사용 문서 예시 업데이트

<br></br>
## 💬 추가 전달 사항
컨벤션에 따른 import/export로 수정했습니다

<br></br>
## 💁‍♂️ 관련 Issues
