### PR TITLE
fix: refresh token 단일 처리 및 인증 초기화 개선

### DIFF
--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -5,8 +5,7 @@ import SearchBar from "@/shared/components/layout/SearchBar";
 import SideNavi from "@/shared/components/layout/SideNavi";
 import Footer from "@/shared/components/layout/Footer";
 import QuickBanner from "@/shared/components/floating/QuickBanner";
-import { cookies } from "next/headers";
-import Providers from "@/shared/components/Providers";
+import AppProvider from "@/shared/providers/AppProvider";
 
 export const metadata = {
   title: {
@@ -23,13 +22,10 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const cookieStore = await cookies();
-  const hasSession = cookieStore.has("refresh");
-
   return (
     <html lang="ko" suppressHydrationWarning>
       <body suppressHydrationWarning>
-        <Providers initialLoggedIn={hasSession}>
+        <AppProvider>
           <LayoutUIProvider>
             <QuickBanner />
             <Header />
@@ -40,7 +36,7 @@ export default async function RootLayout({
             </main>
             <Footer />
           </LayoutUIProvider>
-        </Providers>
+        </AppProvider>
       </body>
     </html>
   );

--- a/apps/client/src/shared/lib/request.ts
+++ b/apps/client/src/shared/lib/request.ts
@@ -49,27 +49,36 @@ async function handleResponse<T>(
   return mode === "data" ? resData.data : resData;
 }
 
-async function refreshToken(): Promise<string> {
-  const res = await fetch(`${getBaseUrl()}/api/proxy/v1/tokens/reissues`, {
+let refreshPromise: Promise<string> | null = null;
+
+export async function refreshToken(): Promise<string> {
+  if (refreshPromise) return refreshPromise;
+
+  refreshPromise = fetch(`${getBaseUrl()}/api/proxy/v1/tokens/reissues`, {
     method: "POST",
     credentials: "include",
-  });
+  })
+    .then(async (res) => {
+      if (!res.ok) {
+        useAuthStore.getState().logout();
+        throw new ApiError({
+          message: "로그인이 만료 되었습니다",
+          status: "401",
+          code: "UNAUTHORIZED",
+        });
+      }
 
-  if (!res.ok) {
-    useAuthStore.getState().logout();
-    throw new ApiError({
-      message: "로그인이 만료 되었습니다",
-      status: "401",
-      code: "UNAUTHORIZED",
+      const data = await res.json();
+      const newAccessToken = data.data.accessToken;
+
+      useAuthStore.getState().login(newAccessToken);
+
+      return newAccessToken;
+    })
+    .finally(() => {
+      refreshPromise = null;
     });
-  }
-
-  const data = await res.json();
-  const newAccessToken = data.data.accessToken;
-
-  useAuthStore.getState().login(newAccessToken);
-
-  return newAccessToken;
+  return refreshPromise;
 }
 
 export default function request<T>(

--- a/apps/client/src/shared/providers/AppProvider.tsx
+++ b/apps/client/src/shared/providers/AppProvider.tsx
@@ -3,18 +3,15 @@
 import { useEffect, useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useAuthStore } from "@/shared/store/auth.store";
+import { refreshToken } from "@/shared/lib/request";
 
 type ProvidersProps = {
   children: React.ReactNode;
-  initialLoggedIn: boolean;
 };
 
-export default function Providers({
-  children,
-  initialLoggedIn,
-}: ProvidersProps) {
+export default function AppProvider({ children }: ProvidersProps) {
   const [isReady, setIsReady] = useState(false);
-  const { login, logout } = useAuthStore();
+  const { logout } = useAuthStore();
 
   const [queryClient] = useState(
     () =>
@@ -29,24 +26,9 @@ export default function Providers({
   );
 
   useEffect(() => {
-    if (!initialLoggedIn) {
-      setIsReady(true);
-      return;
-    }
-    const refresh = async () => {
+    const initAuth = async () => {
       try {
-        const res = await fetch("/api/proxy/v1/tokens/reissues", {
-          method: "POST",
-          credentials: "include",
-        });
-
-        if (!res.ok) {
-          logout();
-          return;
-        }
-
-        const data = await res.json();
-        login(data.data.accessToken);
+        await refreshToken();
       } catch {
         logout();
       } finally {
@@ -54,7 +36,7 @@ export default function Providers({
       }
     };
 
-    refresh();
+    initAuth();
   }, []);
 
   if (!isReady) return null;


### PR DESCRIPTION
## 💻 작업 내용
- accessToken 만료로 발생하는 다중 401 상황에서 refreshToken 중복 호출 문제 수정
- shared promise 패턴을 적용하여 refreshToken 호출을 단일 요청으로 제한
- refreshToken 재발급 완료 후 기존 요청을 새로운 accessToken으로 재시도하도록 처리
- 인증 초기화 시 AppProvider에서 request.ts의 refresh 로직을 재사용하도록 개선
- 동시 API 요청 발생 시 refresh race condition 방지 및 인증 흐름 안정성 개선

<br></br>
## 💬 추가 전달 사항
해결과정 회고에 정리했으니 참고 부탁드립니다.
[refresh 중복 호출 문제 해결](https://www.notion.so/Access-Token-refresh-33b1aba5f2898070a2a6ee52dea239dd?v=2f71aba5f2898031ad0a000cd41be6b1&source=copy_link)

<br></br>
## 💁‍♂️ 관련 Issues
closes #94 
