### PR TITLE
feat: 비회원 장바구니 로컬스토리지 구현

### DIFF
--- a/apps/client/src/app/products/[category]/[productId]/page.tsx
+++ b/apps/client/src/app/products/[category]/[productId]/page.tsx
@@ -40,6 +40,8 @@ export default async function ProductDetailPage({ params }: Props) {
         </div>
         <aside className="lg:sticky lg:top-39.5 lg:col-start-2 lg:row-span-2 lg:row-start-1 lg:self-start">
           <ProductDetailSummary
+            productId={productDetail.id}
+            mainImages={productDetail.mainImageUrl}
             productName={productDetail.productName}
             simpleDescription={productDetail.simpleDescription}
             originalPrice={productDetail.originalPrice}

--- a/apps/client/src/features/auth/components/LoginPageClient.tsx
+++ b/apps/client/src/features/auth/components/LoginPageClient.tsx
@@ -12,6 +12,8 @@ import { Button, CheckBox, Input } from "@repo/ui";
 import LoginKaKaoBtn from "@/features/auth/components/LoginKaKaoBtn";
 import { useRememberId } from "@/features/auth/hook/useRememberId";
 import { useAuthStore } from "@/shared/store/auth.store";
+import { CartItem } from "@/features/cart/model";
+import { fetchAddCart } from "@/features/cart/api";
 
 type FormData = z.infer<typeof loginSchema>;
 
@@ -42,6 +44,19 @@ export default function LoginPageClient() {
       const res = await loginUser(data);
       const { accessToken } = res.data;
       setLogin(accessToken);
+
+      const baskets: CartItem[] = JSON.parse(
+        localStorage.getItem("baskets") ?? "[]"
+      );
+
+      if (baskets.length > 0) {
+        await Promise.all(
+          baskets.map((item) =>
+            fetchAddCart(item.productDetailsId, item.quantity)
+          )
+        );
+        localStorage.removeItem("baskets");
+      }
 
       saveId(data.id);
 

--- a/apps/client/src/features/cart/components/CartList.tsx
+++ b/apps/client/src/features/cart/components/CartList.tsx
@@ -11,7 +11,12 @@ type CartListType = {
     productDetailsId: number
   ) => void;
   onDeleteItem: (id: number) => void;
-  onUpdateOption: (cartId: number, productDetailsId: number) => void;
+  onUpdateOption: (
+    cartId: number,
+    productDetailsId: number,
+    color: string,
+    size: string
+  ) => void;
 };
 
 export default function CartList({
@@ -45,8 +50,8 @@ export default function CartList({
             onUpdateOption={() => setOpenCartId(item.cartId)}
             isOpen={openCartId === item.cartId}
             onClose={() => setOpenCartId(null)}
-            onConfirmOption={(productDetailId) =>
-              onUpdateOption(item.cartId, productDetailId)
+            onConfirmOption={(productDetailId, color, size) =>
+              onUpdateOption(item.cartId, productDetailId, color, size)
             }
           />
         ))}

--- a/apps/client/src/features/cart/hooks/useCart.ts
+++ b/apps/client/src/features/cart/hooks/useCart.ts
@@ -8,17 +8,28 @@ import {
 } from "@/features/cart/api";
 import { useUpdateCartOption } from "@/features/cart/hooks/updateOptionMutation ";
 import { CartItem } from "@/features/cart/model";
+import { useAuthStore } from "@/shared/store/auth.store";
 import { useEffect, useRef, useState } from "react";
 
 export default function useCart() {
   const [items, setItems] = useState<CartItem[]>([]);
   const debounceTimer = useRef<NodeJS.Timeout | null>(null);
+  const { isLoggedIn } = useAuthStore();
+  const getBaskets = (): CartItem[] =>
+    JSON.parse(localStorage.getItem("baskets") ?? "[]");
+  const setBaskets = (baskets: CartItem[]) =>
+    localStorage.setItem("baskets", JSON.stringify(baskets));
 
   const loadCart = async () => {
-    const getCartData = await fetchCart({ size: 8 });
-    const { carts } = getCartData.data;
-    setItems(carts.map((item) => ({ ...item, checked: true })));
+    if (isLoggedIn) {
+      const getCartData = await fetchCart({ size: 8 });
+      const { carts } = getCartData.data;
+      setItems(carts.map((item) => ({ ...item, checked: true })));
+    } else {
+      setItems(getBaskets().map((item) => ({ ...item, checked: true })));
+    }
   };
+
   const updateOptionMutation = useUpdateCartOption(loadCart);
 
   useEffect(() => {
@@ -38,20 +49,40 @@ export default function useCart() {
     setItems((prev) =>
       prev.map((item) => (item.cartId === id ? { ...item, quantity } : item))
     );
-    if (debounceTimer.current) clearTimeout(debounceTimer.current);
-    debounceTimer.current = setTimeout(async () => {
-      await fetchUpdateCart(id, quantity, productDetailsId);
-    }, 500);
+
+    if (isLoggedIn) {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+      debounceTimer.current = setTimeout(async () => {
+        await fetchUpdateCart(id, quantity, productDetailsId);
+      }, 500);
+    } else {
+      setBaskets(
+        getBaskets().map((item) =>
+          item.cartId === id ? { ...item, quantity } : item
+        )
+      );
+    }
   };
 
-  const handleUpdateOption = (cartId: number, productDetailsId: number) => {
-    const quantity = items.find((i) => i.cartId === cartId)!.quantity;
-
-    updateOptionMutation.mutate({
-      cartId,
-      quantity,
-      productDetailsId,
-    });
+  const handleUpdateOption = (
+    cartId: number,
+    productDetailsId: number,
+    color: string,
+    size: string
+  ) => {
+    if (isLoggedIn) {
+      const quantity = items.find((i) => i.cartId === cartId)!.quantity;
+      updateOptionMutation.mutate({ cartId, quantity, productDetailsId });
+    } else {
+      setBaskets(
+        getBaskets().map((item) =>
+          item.cartId === cartId
+            ? { ...item, productDetailsId, color, size }
+            : item
+        )
+      );
+      loadCart();
+    }
   };
 
   const handleToggleAll = () => {
@@ -69,21 +100,41 @@ export default function useCart() {
   };
 
   const handleDeleteItem = async (id: number) => {
-    await fetchDeleteCarts([id]);
-    loadCart();
+    if (isLoggedIn) {
+      await fetchDeleteCarts([id]);
+      loadCart();
+    } else {
+      setBaskets(getBaskets().filter((item) => item.cartId !== id));
+      loadCart();
+    }
   };
 
   const handleDeleteSelected = async () => {
-    const selectIds = items
-      .filter((item) => item.checked)
-      .map((item) => item.cartId);
-    await fetchDeleteCarts(selectIds);
-    loadCart();
+    if (isLoggedIn) {
+      const selectIds = items
+        .filter((item) => item.checked)
+        .map((item) => item.cartId);
+      await fetchDeleteCarts(selectIds);
+      loadCart();
+    } else {
+      const checkedIds = items
+        .filter((item) => item.checked)
+        .map((item) => item.cartId);
+      setBaskets(
+        getBaskets().filter((item) => !checkedIds.includes(item.cartId))
+      );
+      loadCart();
+    }
   };
 
   const handleDeleteAll = async () => {
-    await fetchDeleteAllCarts();
-    loadCart();
+    if (isLoggedIn) {
+      await fetchDeleteAllCarts();
+      loadCart();
+    } else {
+      localStorage.removeItem("baskets");
+      loadCart();
+    }
   };
 
   return {

--- a/apps/client/src/features/cart/model.ts
+++ b/apps/client/src/features/cart/model.ts
@@ -8,6 +8,7 @@ export type CartItem = {
   cartId: number;
   productId: number;
   quantity: number;
+  productDetailsId: number;
   productName: string;
   originalPrice: number;
   discountPrice: number;

--- a/apps/client/src/features/cart/ui/cart-item/CartItem.tsx
+++ b/apps/client/src/features/cart/ui/cart-item/CartItem.tsx
@@ -36,7 +36,11 @@ type CartItemProps = {
   isOpen: boolean;
   onClose: () => void;
   productId: number;
-  onConfirmOption: (productDetailId: number) => void;
+  onConfirmOption: (
+    productDetailId: number,
+    color: string,
+    size: string
+  ) => void;
 };
 
 export default function CartItem({
@@ -106,7 +110,7 @@ export default function CartItem({
       return;
     }
 
-    onConfirmOption(productDetailId);
+    onConfirmOption(productDetailId, selectedColor, selectedSize);
     onClose();
   };
 

--- a/apps/client/src/features/product/components/product-detail/ProductDetailSummary.tsx
+++ b/apps/client/src/features/product/components/product-detail/ProductDetailSummary.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { fetchAddCart } from "@/features/cart/api";
+import { CartItem } from "@/features/cart/model";
 import { ProductOption } from "@/features/product/model";
 import { useAuthStore } from "@/shared/store/auth.store";
 import { DiscountRate } from "@/shared/ui/discount-rate/DiscountRate";
@@ -8,31 +9,24 @@ import { AlertModal, Button, Dropdown } from "@repo/ui";
 import { useMemo, useState } from "react";
 
 type Props = {
+  productId: number;
   productName: string;
   simpleDescription: string;
   originalPrice: number;
   sellingPrice: number;
   discountRate: number;
+  mainImages: string;
   options: ProductOption[];
 };
 
-type BasketItem = {
-  productDetailId: number;
-  productName: string;
-  originalPrice: number;
-  sellingPrice: number;
-  discountRate: number;
-  color: string;
-  size: string;
-  quantity: number;
-};
-
 export default function ProductDetailSummary({
+  productId,
   productName,
   simpleDescription,
   originalPrice,
   sellingPrice,
   discountRate,
+  mainImages,
   options,
 }: Props) {
   // 옵션 선택
@@ -41,6 +35,7 @@ export default function ProductDetailSummary({
   const isOptionSelected = Boolean(selectedColor && selectedSize);
   const [modalMessage, setModalMessage] = useState("");
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const { isLoggedIn } = useAuthStore();
 
   const colorOptions = useMemo(() => {
     return options.map((item) => ({
@@ -121,14 +116,36 @@ export default function ProductDetailSummary({
 
     if (!selectedProductDetailId) return;
 
-    const { isLoggedIn } = useAuthStore.getState();
-
     try {
       if (isLoggedIn) {
         await fetchAddCart(selectedProductDetailId, quantity);
       } else {
         const baskets = JSON.parse(localStorage.getItem("baskets") ?? "[]");
+        const exisringIndex = baskets.findIndex(
+          (item: CartItem) =>
+            item.productId === selectedProductDetailId &&
+            item.color === selectedColor &&
+            item.size === selectedSize
+        );
 
+        if (exisringIndex !== -1) {
+          baskets[exisringIndex].quantity += quantity;
+        } else {
+          baskets.push({
+            cartId: Date.now(),
+            productId,
+            productDetailsId: selectedProductDetailId,
+            quantity,
+            productName,
+            originalPrice,
+            discountPrice: sellingPrice,
+            discountRate,
+            color: selectedColor,
+            size: selectedSize,
+            mainImageUrl: mainImages,
+            checked: true,
+          });
+        }
         localStorage.setItem("baskets", JSON.stringify(baskets));
       }
       setModalMessage("장바구니에 담겼습니다.");

--- a/apps/client/src/shared/lib/refreshToken.ts
+++ b/apps/client/src/shared/lib/refreshToken.ts
@@ -1,0 +1,34 @@
+import { ApiError } from "./error";
+import { useAuthStore } from "@/shared/store/auth.store";
+
+let refreshPromise: Promise<string> | null = null;
+
+export async function refreshToken(): Promise<string> {
+  if (refreshPromise) return refreshPromise;
+
+  refreshPromise = fetch(`/api/proxy/v1/tokens/reissues`, {
+    method: "POST",
+    credentials: "include",
+  })
+    .then(async (res) => {
+      if (!res.ok) {
+        useAuthStore.getState().logout();
+        throw new ApiError({
+          message: "로그인이 만료 되었습니다",
+          status: "401",
+          code: "UNAUTHORIZED",
+        });
+      }
+
+      const data = await res.json();
+      const newAccessToken = data.data.accessToken;
+      useAuthStore.getState().login(newAccessToken);
+
+      return newAccessToken;
+    })
+    .finally(() => {
+      refreshPromise = null;
+    });
+
+  return refreshPromise;
+}

--- a/apps/client/src/shared/lib/request.ts
+++ b/apps/client/src/shared/lib/request.ts
@@ -2,6 +2,7 @@ import { ApiError } from "./error";
 import { isApiResponse } from "./api-response.guard";
 import { ApiResponse } from "@repo/types";
 import { useAuthStore } from "@/shared/store/auth.store";
+import { refreshToken } from "@/shared/lib/refreshToken";
 
 function getBaseUrl() {
   if (typeof window !== "undefined") return "";
@@ -47,38 +48,6 @@ async function handleResponse<T>(
   }
 
   return mode === "data" ? resData.data : resData;
-}
-
-let refreshPromise: Promise<string> | null = null;
-
-export async function refreshToken(): Promise<string> {
-  if (refreshPromise) return refreshPromise;
-
-  refreshPromise = fetch(`${getBaseUrl()}/api/proxy/v1/tokens/reissues`, {
-    method: "POST",
-    credentials: "include",
-  })
-    .then(async (res) => {
-      if (!res.ok) {
-        useAuthStore.getState().logout();
-        throw new ApiError({
-          message: "로그인이 만료 되었습니다",
-          status: "401",
-          code: "UNAUTHORIZED",
-        });
-      }
-
-      const data = await res.json();
-      const newAccessToken = data.data.accessToken;
-
-      useAuthStore.getState().login(newAccessToken);
-
-      return newAccessToken;
-    })
-    .finally(() => {
-      refreshPromise = null;
-    });
-  return refreshPromise;
 }
 
 export default function request<T>(

--- a/apps/client/src/shared/providers/AppProvider.tsx
+++ b/apps/client/src/shared/providers/AppProvider.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useAuthStore } from "@/shared/store/auth.store";
-import { refreshToken } from "@/shared/lib/request";
+import { refreshToken } from "@/shared/lib/refreshToken";
 
 type ProvidersProps = {
   children: React.ReactNode;


### PR DESCRIPTION
## 💻 작업 내용
- 비회원 장바구니 담기/중복 수량 합산 처리
- 비회원 장바구니 불러오기/수량변경/옵션변경/삭제 구현
- 로그인 시 로컬스토리지 장바구니 서버로 이전
- refreshToken 분리
- useCart 훅 비회원/회원 분기 처리
- getBaskets/setBaskets 유틸 함수로 리팩토링

<br></br>
## 💬 추가 전달 사항

<br></br>
## 💁‍♂️ 관련 Issues
#67
